### PR TITLE
Refactor routes: extract SSE and link-preview queue into services

### DIFF
--- a/server/events.ts
+++ b/server/events.ts
@@ -1,0 +1,30 @@
+import type { FastifyInstance, FastifyReply } from "fastify";
+
+export type BroadcastFn = (event: string) => void;
+
+export function createEventBroadcaster() {
+  const sseClients = new Set<FastifyReply>();
+
+  const broadcast: BroadcastFn = (event) => {
+    for (const client of sseClients) {
+      client.raw.write(`event: ${event}\ndata: {}\n\n`);
+    }
+  };
+
+  const registerEventRoutes = (app: FastifyInstance) => {
+    app.get("/api/events", (_req, reply) => {
+      reply.raw.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      reply.raw.write("\n");
+      sseClients.add(reply);
+      reply.raw.on("close", () => {
+        sseClients.delete(reply);
+      });
+    });
+  };
+
+  return { broadcast, registerEventRoutes };
+}

--- a/server/link-preview-queue.ts
+++ b/server/link-preview-queue.ts
@@ -1,0 +1,36 @@
+import type { FastifyBaseLogger } from "fastify";
+import type { KeeperDB } from "../src/db/types.ts";
+import { extractSingleUrl } from "../src/db/url-detect.ts";
+import { fetchOgImage } from "./link-preview.ts";
+import type { BroadcastFn } from "./events.ts";
+
+export function createLinkPreviewQueue(params: {
+  db: KeeperDB;
+  log: FastifyBaseLogger;
+  broadcast: BroadcastFn;
+}) {
+  const { db, log, broadcast } = params;
+
+  return function queueLinkPreview(body: string) {
+    const url = extractSingleUrl(body);
+    if (url === null) return;
+
+    void (async () => {
+      try {
+        const settings = await db.getAppSettings();
+        if (!settings.linkPreviewFetchEnabled) return;
+        const existing = await db.getLinkPreview(url);
+        if (existing !== null) return;
+        const result = await fetchOgImage(url);
+        await db.upsertLinkPreview({
+          url,
+          image_url: result.imageUrl,
+          status: result.status,
+        });
+        if (result.status === "found") broadcast("refresh");
+      } catch (error) {
+        log.warn({ error, url }, "Failed to fetch link preview");
+      }
+    })();
+  };
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -8,60 +8,23 @@ import type {
 } from "../src/db/types.ts";
 import { bufferToArrayBuffer, type MediaHandler } from "./media-handler.ts";
 import { truncateExtensionTitle } from "../src/utils/extension-title.ts";
-import { extractSingleUrl } from "../src/db/url-detect.ts";
-import { fetchOgImage } from "./link-preview.ts";
+import { createEventBroadcaster } from "./events.ts";
+import { createLinkPreviewQueue } from "./link-preview-queue.ts";
 
 export function registerRoutes(
   app: FastifyInstance,
   db: KeeperDB,
   media: MediaHandler,
 ): void {
-  // ── SSE (Server-Sent Events) ─────────────
-
-  const sseClients = new Set<FastifyReply>();
-
-  function broadcast(event: string) {
-    for (const client of sseClients) {
-      client.raw.write(`event: ${event}\ndata: {}\n\n`);
-    }
-  }
-
-  function queueLinkPreview(body: string) {
-    const url = extractSingleUrl(body);
-    if (url === null) return;
-
-    void (async () => {
-      try {
-        const settings = await db.getAppSettings();
-        if (!settings.linkPreviewFetchEnabled) return;
-        const existing = await db.getLinkPreview(url);
-        if (existing !== null) return;
-        const result = await fetchOgImage(url);
-        await db.upsertLinkPreview({
-          url,
-          image_url: result.imageUrl,
-          status: result.status,
-        });
-        if (result.status === "found") broadcast("refresh");
-      } catch (error) {
-        app.log.warn({ error, url }, "Failed to fetch link preview");
-      }
-    })();
-  }
-
-  app.get("/api/events", (_req, reply) => {
-    reply.raw.writeHead(200, {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
-    });
-    reply.raw.write("\n");
-    sseClients.add(reply);
-    reply.raw.on("close", () => {
-      sseClients.delete(reply);
-    });
-    // Don't call reply.send() — we keep the connection open
+  const { broadcast, registerEventRoutes } = createEventBroadcaster();
+  const queueLinkPreview = createLinkPreviewQueue({
+    db,
+    log: app.log,
+    broadcast,
   });
+
+  registerEventRoutes(app);
+
 
   // ── Notes ──────────────────────────────────
 


### PR DESCRIPTION
### Motivation
- `server/routes.ts` was acting as a traffic controller plus business logic by embedding SSE client lifecycle and link-preview queueing. 
- The intent is to separate concerns so route registration focuses on wiring and small services encapsulate behavior. 

### Description
- Added `server/events.ts` which exports `createEventBroadcaster()` providing `broadcast` and `registerEventRoutes` to encapsulate SSE client management. 
- Added `server/link-preview-queue.ts` which exports `createLinkPreviewQueue()` to encapsulate URL extraction, settings gating, OG fetch, DB upsert, and refresh broadcasting. 
- Simplified `server/routes.ts` to compose the two new services (`createEventBroadcaster` and `createLinkPreviewQueue`) and removed the in-file SSE and queue logic. 

### Testing
- Ran `npm run lint` which completed successfully. 
- Ran `npm test` (Vitest), and the test suite completed successfully with all tests passing (296 tests passed). 
- Ran `npm run build` which produced a successful TypeScript build and frontend `vite build` output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86262e0888331b0d5ea1e892e55f7)